### PR TITLE
Replace deprecated options.

### DIFF
--- a/qemu.initd
+++ b/qemu.initd
@@ -49,7 +49,7 @@ command_args="
 	-realtime mlock=off
 	-rtc base=$rtc_base
 	-smp cpus=$smp_cpus,maxcpus=$smp_cpus_max
-	-balloon virtio
+	-device virtio-balloon
 	-vga $vga
 	-device virtio-rng-pci
 	-device virtio-scsi-pci,id=scsi


### PR DESCRIPTION
Some versions before 3.1.0 -balloon option was deprecated.
Starting with QEMU 3.1.0 it is no longer recognized and needs to be replaced with -device virtio-balloon.