### PR TITLE
fix init script to run on current gentoo

### DIFF
--- a/qemu.initd
+++ b/qemu.initd
@@ -195,7 +195,7 @@ suspend() {
 }
 
 vmstatus() {
-	qemush_show 'info status' | xargs einfo
+	qemush_show 'info status' | tr -d '\r' | xargs einfo
 }
 
 version() {

--- a/qemu.initd
+++ b/qemu.initd
@@ -255,7 +255,7 @@ net_args() {
 			opts=$(set | sed -En "s/^net${idx}_(.*)/\1/p" \
 					| grep -Ev '^(mac|device)=.*$' \
 					| tr $'\n' ',')
-			mac=$(getval ${net_id}_mac "$(gen_macaddr ${VM_NAME}%${idx})")
+			mac=$(getval ${net_id}_mac "$(gen_macaddr ${VM_NAME}#${idx})")
 			dev=$(getval ${net_id}_device virtio-net-pci)
 
 			echo "-netdev ${net_type},${opts}id=hostnet${idx}"


### PR DESCRIPTION
* changed special character in mac_generation
* vmstatus is working again
* -balloon isn't working in current qemu version anymore