### PR TITLE
qemush: Use printf instead of echo -e.

### DIFF
--- a/qemu.initd
+++ b/qemu.initd
@@ -281,12 +281,12 @@ check_bridge() {
 
 qemush() {
 	local IFS=$'\n'
-	echo -e "$*" | socat - "UNIX-CONNECT:${monitor_socket}" 1>/dev/null
+	printf "%b\n" "$*" | socat - "UNIX-CONNECT:${monitor_socket}" 1>/dev/null
 }
 
 qemush_show() {
 	local IFS=$'\n'
-	echo -e "$*" | socat - "UNIX-CONNECT:${monitor_socket}" | tail -n +3 | head -n -1
+	printf "%b\n" "$*" | socat - "UNIX-CONNECT:${monitor_socket}" | tail -n +3 | head -n -1
 }
 
 gen_macaddr() {

--- a/qemush
+++ b/qemush
@@ -50,7 +50,7 @@ fi
 if [ -n "$2" ]; then
 	IFS=$'\n'
 	shift
-	echo -e "$*" | socat - "UNIX-CONNECT:$socket_path"
+	printf "%b\n" "$*" | socat - "UNIX-CONNECT:$socket_path"
 else
 	echo 'Connecting to QEMU monitor in interactive mode. Use Ctrl+O to exit.'
 	echo 'Note: command "quit" does not exit the monitor, but stops VM!'


### PR DESCRIPTION
In POSIX shells like dash, `echo -e` does not work and printf should be preferred.