### PR TITLE
fix up qemu-binfmt for current Alpine

### DIFF
--- a/qemu-binfmt.initd
+++ b/qemu-binfmt.initd
@@ -30,7 +30,7 @@ FMTS="7f454c460201010000000000000000000200b7 ffffffffffffff00fffffffffffffffffef
 	7f454c460202010000000000000000000002002b fffffffffffffffffffffffffffffffffffeffff sparc64"
 
 : ${binfmt_flags:=OCF}
-: ${qemu_suffix=-static}
+: ${qemu_suffix:=}
 
 describe='Configure binfmt misc emulation via QEMU'
 

--- a/qemu-binfmt.initd
+++ b/qemu-binfmt.initd
@@ -29,7 +29,7 @@ FMTS="7f454c460201010000000000000000000200b7 ffffffffffffff00fffffffffffffffffef
 	7f454c4601020100000000000000000000020012 fffffffffffffffffffffffffffffffffffeffff sparc32plus
 	7f454c460202010000000000000000000002002b fffffffffffffffffffffffffffffffffffeffff sparc64"
 
-: ${binfmt_flags:=OC}
+: ${binfmt_flags:=OCF}
 : ${qemu_suffix=-static}
 
 describe='Configure binfmt misc emulation via QEMU'


### PR DESCRIPTION
I use qemu-binfmt service to run LXC containers for other architectures.  These are the changes I needed to accomplish that.