### PR TITLE
-realtime is deprecated, replace with -overcommit

### DIFF
--- a/qemu.initd
+++ b/qemu.initd
@@ -46,7 +46,7 @@ command_args="
 	-nodefaults
 	-no-user-config
 	-cpu $cpu_model
-	-realtime mlock=off
+	-overcommit mem-lock=off
 	-rtc base=$rtc_base
 	-smp cpus=$smp_cpus,maxcpus=$smp_cpus_max
 	-device virtio-balloon


### PR DESCRIPTION
https://gitlab.com/qemu-project/qemu/-/commit/583f34c493fc5b91aa05a8987023244a72f8efae

Information about this gets written into VM logs every boot, kinda annoying. 