### PR TITLE
add VM_NAME variable to confd

### DIFF
--- a/qemu.confd
+++ b/qemu.confd
@@ -16,6 +16,9 @@
 # suitable for you, then you can omit that variable in your VM config.
 #
 
+# Name of virtual machine, by default /etc/conf.d/qemu.<VM_NAME>
+# Enable when you change variables containing it.
+#VM_NAME="${RC_SVCNAME#qemu.}"
 
 # User to run the QEMU process.
 #user="qemu"


### PR DESCRIPTION
This might have worked in the past, but now variables specified in initd are empty in confd.
