### PR TITLE
Fix mask for sparc64 magic

### DIFF
--- a/qemu-binfmt.initd
+++ b/qemu-binfmt.initd
@@ -28,7 +28,7 @@ FMTS="7f454c460201010000000000000000000200b7 ffffffffffffff00fffffffffffffffffef
 	7f454c460102010000000000000000000002002a ffffffffffffff00fffffffffffffffffffeffff sh4eb
 	7f454c4601020100000000000000000000020002 fffffffffffffffffffffffffffffffffffeffff sparc
 	7f454c4601020100000000000000000000020012 fffffffffffffffffffffffffffffffffffeffff sparc32plus
-	7f454c460202010000000000000000000002002b fffffffffffffffffffffffffffffffffffeffff sparc64"
+	7f454c460202010000000000000000000002002b fffffffffffffffcfffffffffffffffffffeffff sparc64"
 
 : ${binfmt_flags:=OCF}
 : ${qemu_suffix:=}


### PR DESCRIPTION
This is needed for UltraSPARC binaries to run under qemu-user.