### PR TITLE
Add support for loongarch64

### DIFF
--- a/qemu-binfmt.initd
+++ b/qemu-binfmt.initd
@@ -12,6 +12,7 @@ FMTS="7f454c460201010000000000000000000200b7 ffffffffffffff00fffffffffffffffffef
 	7f454c4601010100000000000000000002004c00 ffffffffffffff00fffffffffffffffffeffffff cris
 	7f454c4601010100000000000000000002000300 fffffffffffefefffffffffffffffffffeffffff i386
 	7f454c4601010100000000000000000002000600 fffffffffffefefffffffffffffffffffeffffff i486
+	7f454c4602010100000000000000000002000201 fffffffffffffffc00fffffffffffffffeffffff loongarch
 	7f454c4601020100000000000000000000020004 ffffffffffffff00fffffffffffffffffffeffff m68k
 	7f454c460102010000000000000000000002baab ffffffffffffff00fffffffffffffffffffeffff microblaze
 	7f454c4601020100000000000000000000020008 ffffffffffffff00fefffffffffffffffffeffff mips
@@ -100,6 +101,7 @@ normalize_arch() {
 	case "$1" in
 		i[3456]86) echo 'i386';;
 		armv[4-9]*) echo 'arm';;
+		loongarch) echo 'loongarch64';;
 		*) echo "$1";;
 	esac
 }


### PR DESCRIPTION
Based on the qemu binfmt registration script. Note that the qemu architecture is called loongarch64 while loongarch is used in the binfmt registration; hence, we need to adjust normalize_arch() accordingly as well. This is especially useful for Alpine and `abuild rootbld`-based debugging as Alpine is now getting a loongarch64 port.