### PR TITLE
Preserve argv0 by default in qemu-binfmt

### DIFF
--- a/qemu-binfmt.initd
+++ b/qemu-binfmt.initd
@@ -34,7 +34,7 @@ FMTS="7f454c460201010000000000000000000200b7 ffffffffffffff00fffffffffffffffffef
 	7f454c460202010000000000000000000002002b fffffffffffffffcfffffffffffffffffffeffff sparc64
 	7f454c4602010100000000000000000002003e00 fffffffffffefe00fffffffffffffffffeffffff x86_64"
 
-: ${binfmt_flags:=OCF}
+: ${binfmt_flags:=POCF}
 : ${qemu_suffix:=}
 
 describe='Configure binfmt misc emulation via QEMU'


### PR DESCRIPTION
Otherwise programs parsing argv0 may not run correctly. For backwords compatibility reasons this option is not enabled by default but qemu understands it so this should not introduce any issues.

Ref https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html \
Ref https://gitlab.com/qemu-project/qemu/-/commit/6e1c0d7b951e19c53b8467e8bc4b71ee73a394ea \
Fixes https://gitlab.alpinelinux.org/alpine/abuild/-/issues/10182